### PR TITLE
Address HDF5 library mismatch error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - cmocean
   - echopype==0.5.4
+  - h5netcdf==0.11.0
   - matplotlib
   - numpy
   - pandas


### PR DESCRIPTION
Addresses an incompatibility between the HDF5 libraries used by h5py and h5netcdf by pinning h5netcdf to version 0.11.0. Subsequent versions of h5netcdf (0.12.0, 0.13.0, and 0.13.1) released in the past month are incompatible with h5py and throw an `undefined symbol: H5Pset_fapl_ros3` error.